### PR TITLE
Add Additional Endpoints to "Top Up" via Search function

### DIFF
--- a/backend/src/chars/char-abstract.service.ts
+++ b/backend/src/chars/char-abstract.service.ts
@@ -6,10 +6,13 @@ export abstract class CharacterServiceProvider<T extends BaseEntity> {
 
   public abstract ingestCharacter(id: string): Promise<T | null>;
   public abstract ingestCharacters(pageNumber: number): Promise<T[]>;
-  public abstract freshCharacters(): Promise<any>;
+  public abstract freshCharacters(searchQuery: string): Promise<any>;
+  public abstract freshCharactersBySearch(maxPageNumber: number, searchQuery: string, startingPage: number): Promise<any>;
   public abstract makeCharacterFromDTO(dto: unknown): Promise<T>;
   public abstract search(query: string | undefined, searchType: SearchType | undefined, pageNum: number): Promise<{ result: T[], total: number }>;
   public abstract getLatestCharacters(count: number): Promise<T[]>;
+
+
 
   public async getCharacterById(id: string): Promise<T | null> {
     return this.repository.createQueryBuilder('char')

--- a/backend/src/chub/chub.controller.ts
+++ b/backend/src/chub/chub.controller.ts
@@ -27,7 +27,17 @@ export default class ChubController {
     @Body('searchQuery') searchQuery: string,
     @Body('startPage') startPage: number,
   ) {
-    return this.chubService.freshCharactersBySearch(maxPage, searchQuery, startPage);
+    // Start the ingestion process in the background
+    this.chubService.freshCharactersBySearch(maxPage, searchQuery, startPage)
+      .then(() => {
+        console.log('Ingestion process completed.');
+      })
+      .catch((error) => {
+        console.error('Ingestion process failed:', error);
+      });
+  
+    // Immediately return a response to the client
+    return { message: 'Ingest has been started' };
   }
 
   @Post('ingestAll')

--- a/backend/src/chub/chub.controller.ts
+++ b/backend/src/chub/chub.controller.ts
@@ -20,6 +20,16 @@ export default class ChubController {
     return chubCharacter;
   }
 
+  @Post('ingestBySearch')
+  async ingestCharactersBySearch(
+    @Req() req: Request,
+    @Body('maxPage') maxPage: number,
+    @Body('searchQuery') searchQuery: string,
+    @Body('startPage') startPage: number,
+  ) {
+    return this.chubService.freshCharactersBySearch(maxPage, searchQuery, startPage);
+  }
+
   @Post('ingestAll')
   async ingestPage(
     @Req() req: Request,

--- a/backend/src/chub/chub.service.ts
+++ b/backend/src/chub/chub.service.ts
@@ -56,12 +56,47 @@ export default class ChubCharactersService extends CharacterServiceProvider<Chub
     ).then((chars) => chars.filter(char => char !== null) as ChubCharacter[]);
   }
 
+  public async ingestAllCharacters(maxPageNumber: number, searchQuery: string, startingPage: number = 1): Promise<ChubCharacter[]> {
+    await this.ingestTags();
+    let pageNumber = startingPage;
+    let allCharacters: ChubCharacter[] = [];
+  
+    while (pageNumber <= maxPageNumber) {
+      try {
+        const { results, total } = await this.api.getCharacters(this, pageNumber, 'desc', searchQuery);
+        if (!results.length) {
+          break; // Exit loop if no more results
+        }
+  
+        const pageCharacters = await Promise.all(
+          results.map(async (chubCharacter) =>
+            this.api.getCharacter(this, chubCharacter.fullPath)
+              .then((char) => char ? this.saveIngestableCharacter(char) : null)
+          )
+        );
+  
+        allCharacters = [...allCharacters, ...pageCharacters.filter(char => char !== null) as ChubCharacter[]];
+        pageNumber++;
+      } catch (error) {
+        this.logger.error(`Error fetching page ${pageNumber}: ${error}`);
+        break;
+      }
+    }
+  
+    return allCharacters;
+  }  
+
   @Cron('0 10 * * * *')
   public async freshCharacters() {
     this.logger.log(`CHUB: INGESTING FRESH CHARS...`);
     return this.ingestCharacters(1);
   }
 
+  public async freshCharactersBySearch(maxPageNumber: number, searchQuery: string, startingPage: number = 1) {
+    this.logger.log(`CHUB: INGESTING RECENT CHARS VIA SEARCH TERM: ${searchQuery} STARTPAGE: ${startingPage} MAXPAGE: ${maxPageNumber}`);
+    return this.ingestAllCharacters(maxPageNumber, searchQuery, startingPage);
+  }
+  
   public async makeCharacterFromDTO(node: {  [key: string]: any }, skipAssets = false): Promise<ChubCharacter> {
     const result = new ChubCharacter();
     Object.assign(result, node);

--- a/backend/src/janitor/janitor.controller.ts
+++ b/backend/src/janitor/janitor.controller.ts
@@ -21,7 +21,6 @@ export class JanitorController {
   @Post('ingestBySearch')
   async ingestCharactersBySearch(
     @Req() req: Request,
-    @Res() res: Response,
     @Body('maxPage') maxPage: number,
     @Body('searchQuery') searchQuery: string,
     @Body('startPage') startPage: number,
@@ -36,7 +35,7 @@ export class JanitorController {
       });
   
     // Immediately return a response to the client
-    return res.status(202).send({ message: 'Ingest has been started' });
+    return { message: 'Ingest has been started' };
   }
 
   @Post('ingestAll')

--- a/backend/src/janitor/janitor.controller.ts
+++ b/backend/src/janitor/janitor.controller.ts
@@ -18,6 +18,27 @@ export class JanitorController {
     return jCharacter;
   }
 
+  @Post('ingestBySearch')
+  async ingestCharactersBySearch(
+    @Req() req: Request,
+    @Res() res: Response,
+    @Body('maxPage') maxPage: number,
+    @Body('searchQuery') searchQuery: string,
+    @Body('startPage') startPage: number,
+  ) {
+    // Start the ingestion process in the background
+    this.janitorCharService.freshCharactersBySearch(maxPage, searchQuery, startPage)
+      .then(() => {
+        console.log('Ingestion process completed.');
+      })
+      .catch((error) => {
+        console.error('Ingestion process failed:', error);
+      });
+  
+    // Immediately return a response to the client
+    return res.status(202).send({ message: 'Ingest has been started' });
+  }
+
   @Post('ingestAll')
   async ingestPage(
     @Req() req: Request,

--- a/backend/src/lib/chub.api.ts
+++ b/backend/src/lib/chub.api.ts
@@ -11,14 +11,14 @@ export default class ChubApi extends CharacterApi<ChubCharacter> {
     super(CHUB_API);
   }
 
-  public async getCharacters(charService: ChubCharactersService, page = 1, order: 'desc' | 'asc' = 'desc'): Promise<{ results: ChubCharacter[], total: number }> {
+  public async getCharacters(charService: ChubCharactersService, page = 1, order: 'desc' | 'asc' = 'desc', searchQuery = ''): Promise<{ results: ChubCharacter[], total: number }> {
     console.log(`CHUB: PROCESSING PAGE ${page}...`);
     // https://api.chub.ai/search?search=&first=10&topics=&excludetopics=&page=1&sort=created_at&venus=true&min_tokens=50&nsfw=true
-    const key = `/search?search=&first=${SEARCH_PAGE_SIZE}&topics=&excludetopics=&page=${page}&sort=id&asc=${order === 'asc'}&venus=true&min_tokens=${SEARCH_MIN_TOKENS}&nsfw=true`;
-
+    const key = `/search?search=${encodeURIComponent(searchQuery)}&first=${SEARCH_PAGE_SIZE}&topics=&excludetopics=&page=${page}&sort=id&asc=${order === 'asc'}&venus=true&min_tokens=${SEARCH_MIN_TOKENS}&nsfw=true`;
+  
     const result = await this.client.get<ChubCharacterSearchDTO>(key);
     if (!result?.data?.data?.nodes.length) return { results: [], total: 0 };
-
+  
     const total = result.data.data.count;
     const results = await Promise.all(
       result.data.data.nodes.map((node: { [key: string]: any }) => charService.makeCharacterFromDTO(node, true))
@@ -26,7 +26,7 @@ export default class ChubApi extends CharacterApi<ChubCharacter> {
     return {
       results, total,
     };
-  }
+  }  
 
   public async getCharacter(charService: ChubCharactersService, fullPath: string): Promise<ChubCharacter | null> {
     if (!fullPath) return null;

--- a/backend/src/lib/janitor.api.ts
+++ b/backend/src/lib/janitor.api.ts
@@ -28,21 +28,21 @@ export default class JanitorApi extends CharacterApi<JanitorCharacter> {
     return charService.makeCharacterFromDTO(dto);
   }
 
-  public async getCharacters(charService: JanitorCharacterService, page = 1): Promise<{ results: JanitorCharacter[], total: number }> {
-    const key = `${JANITOR_API_ROOT}/characters?page=${page}&search=&mode=all&sort=latest`;
-
+  public async getCharacters(charService: JanitorCharacterService, page = 1, searchQuery = ''): Promise<{ results: JanitorCharacter[], total: number }> {
+    const key = `${JANITOR_API_ROOT}/characters?page=${page}&search=${encodeURIComponent(searchQuery)}&mode=all&sort=latest`;
+  
     const result = await this
       .get<{ data: JanitorCharacterDto[], total: number, size: number, page: number }>(key);
-
+  
     console.log(`JANITOR: PROCESSING PAGE ${page}...`);
-
+  
     if (!result.data.length) return { results: [], total: 0 };
     const characters = await Promise.all(
       result.data.map((dto) => charService.makeCharacterFromDTO(dto)),
     );
-
+  
     return { results: characters, total: result.total };
-  }
+  }  
 
   public async getTags(charService: JanitorCharacterService): Promise<string[]> {
     const key = `${JANITOR_API_ROOT}/tags`;


### PR DESCRIPTION
It modifies the Existing Service and Abstract to add two new functions.

Essentially it's a function which can also be called via the API for both Janitor and Chub to fetch x pages of search results.

It can be used to "top up" characters which are engineers by doing:

`{
    "maxPage": 10,
    "searchQuery": "engineer",
    "startPage": 1
}`

It will start at Page 1 and keep going until it either hits an empty page (end of results) or max page.

It does ONLY add an API endpoint, so tools like Insomnia are required to make that request by hand.

The paths are:
http://backend:3000/chub/ingestBySearch
http://backend:3000/janitor/ingestBySearch